### PR TITLE
Add official website link in header

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
     .social-icons a { display: inline-block; margin: 0 5px;}
     .social-icons img { width: 31px; height: 31px; border-radius: 50%; transition: 0.2s; vertical-align: middle;}
     .social-icons img:hover { transform: scale(1.12);}
+    .website-link { display: inline-block; margin-top: 10px; background: #C70039; color: #fff; padding: 6px 14px; border-radius: 999px; font-size: 14px; text-decoration: none; transition: 0.2s; }
+    .website-link:hover { background: #a5002d; }
     .products-list { max-width: 500px; margin: 20px auto 25px auto; padding: 0 6px;}
     .product-card { background: #fff; border-radius: 14px; box-shadow: 0 1px 8px #ececec; margin-bottom: 19px; padding: 18px 13px; display: flex; gap: 12px; align-items: center; position: relative;}
     .product-img { width: 82px; height: 82px; object-fit: contain; border-radius: 11px; border: 1.5px solid #efefef; background: #fafafa;}
@@ -40,6 +42,9 @@
   <header>
     <img src="https://i.imgur.com/SBzQpT5.png" class="logo" alt="logo">
     <span class="brand-name">American Box</span>
+    <div>
+      <a class="website-link" href="https://www.americanbox-eg.com/" target="_blank" rel="noreferrer">الموقع الرسمي</a>
+    </div>
     <div class="pay-section">
       <div class="pay-item">
         <span class="pay-label"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/fa/Vodafone_icon.svg/32px-Vodafone_icon.svg.png" class="icon" alt="vodafone"> Vodafone Cash:</span>


### PR DESCRIPTION
### Motivation
- Provide a prominent, branded link to the official site so visitors can quickly navigate to `https://www.americanbox-eg.com/` from the storefront page.

### Description
- Add a new styled header button by introducing the `.website-link` CSS rule and inserting `<a class="website-link" href="https://www.americanbox-eg.com/" target="_blank" rel="noreferrer">الموقع الرسمي</a>` into the header of `index.html`.
- Only `index.html` was modified to include the new link and its hover styling.

### Testing
- Started a local static server with `python -m http.server` and used Playwright to load `index.html` and capture a full-page screenshot which produced the artifact `artifacts/americanbox-home.png` successfully.
- No unit tests were present or run for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69684907b788832b9c69c625defa9f39)